### PR TITLE
feat(server): implemented custom response messages

### DIFF
--- a/apps/server/src/controllers/auth/sign-in.ts
+++ b/apps/server/src/controllers/auth/sign-in.ts
@@ -3,7 +3,7 @@ import { Request, Response } from 'express';
 import bcrypt from 'bcrypt';
 import Jwt from 'jsonwebtoken';
 import { UserProvider } from '../../providers/user';
-import { HttpStatusCodes, ApiResponse } from '../../utils';
+import { HttpStatusCodes, ApiResponse, MessageCodes } from '../../utils';
 import { UserInterface } from '../../interfaces';
 const secret = process.env.JWT_SECRET || 'secret';
 
@@ -16,7 +16,11 @@ export const signIn = async (req: Request, res: Response) => {
 			true
 		);
 		if (!userFromDb) {
-			return ApiResponse.error(res, HttpStatusCodes.NOT_FOUND, 'User not found');
+			return ApiResponse.error(
+				res,
+				HttpStatusCodes.NOT_FOUND,
+				MessageCodes.USER_NOT_FOUND
+			);
 		}
 
 		const passwordMatches = userFromDb?.password
@@ -24,7 +28,11 @@ export const signIn = async (req: Request, res: Response) => {
 			: '';
 
 		if (!passwordMatches) {
-			return ApiResponse.error(res, HttpStatusCodes.UNAUTHORIZED, 'User password invalid');
+			return ApiResponse.error(
+				res,
+				HttpStatusCodes.UNAUTHORIZED,
+				MessageCodes.LOGIN_DENIED
+			);
 		}
 
 		if (userFromDb.deletedAt && userFromDb.id) {
@@ -39,12 +47,21 @@ export const signIn = async (req: Request, res: Response) => {
 			ApiResponse.error(
 				res,
 				HttpStatusCodes.INTERNAL_SERVER_ERROR,
-				'bad credentials'
+				MessageCodes.INTERNAL_SERVER_ERROR
 			);
 		}
 
-		return ApiResponse.success(res, HttpStatusCodes.SUCCESS, { token, user: userPublicInfo }, 'Sign in successfully');
+		return ApiResponse.success(
+			res,
+			HttpStatusCodes.SUCCESS,
+			{ token, user: userPublicInfo },
+			MessageCodes.LOGIN_SUCCES
+		);
 	} catch (error) {
-		return ApiResponse.error(res, HttpStatusCodes.INTERNAL_SERVER_ERROR, 'Internal server error');
+		return ApiResponse.error(
+			res,
+			HttpStatusCodes.INTERNAL_SERVER_ERROR,
+			MessageCodes.INTERNAL_SERVER_ERROR
+		);
 	}
 };

--- a/apps/server/src/controllers/auth/sign-up.ts
+++ b/apps/server/src/controllers/auth/sign-up.ts
@@ -3,10 +3,9 @@ import { Request, Response } from 'express';
 import { ValidationError } from 'sequelize';
 
 import { UserProvider } from '../../providers/user';
-import { HttpStatusCodes, sendApiError, sendApiResponse } from '../../utils';
+import { HttpStatusCodes, ApiResponse, MessageCodes } from '../../utils';
 
 const secret = process.env.JWT_SECRET || 'secret';
-
 
 export const signUp = async (req: Request, res: Response) => {
 	const { username, email, password } = req.body;
@@ -21,7 +20,7 @@ export const signUp = async (req: Request, res: Response) => {
 			return ApiResponse.error(
 				res,
 				HttpStatusCodes.CONFLICT,
-				'Username already in use'
+				MessageCodes.REGISER_DENIED
 			);
 		}
 
@@ -32,24 +31,41 @@ export const signUp = async (req: Request, res: Response) => {
 			return ApiResponse.error(
 				res,
 				HttpStatusCodes.CONFLICT,
-				'Email already exists'
+				MessageCodes.REGISER_DENIED
 			);
 		}
 
 		const user = await UserProvider.createUser({ username, email, password });
 		if (!user) {
-			ApiResponse.error(res, HttpStatusCodes.INTERNAL_SERVER_ERROR, 'Error while creating user');
+			ApiResponse.error(
+				res,
+				HttpStatusCodes.INTERNAL_SERVER_ERROR,
+				MessageCodes.REGISER_DENIED
+			);
 		}
 
 		const expDate = Date.now() + 1000 * 60 * 48;
 		const token = Jwt.sign({ sub: user.id, exp: expDate }, secret);
 
-		const userWithPublicData = await UserProvider.get.byUsername(username)
-		sendApiResponse(res, HttpStatusCodes.CREATED, { token, user: userWithPublicData });
+		const userWithPublicData = await UserProvider.getUser.byUsername(username);
+		ApiResponse.success(
+			res,
+			HttpStatusCodes.CREATED,
+			{ token, user: userWithPublicData },
+			MessageCodes.REGISER_SUCCES
+		);
 	} catch (error) {
 		if (error instanceof ValidationError) {
-			sendApiError(res, HttpStatusCodes.BAD_REQUEST);
+			ApiResponse.error(
+				res,
+				HttpStatusCodes.BAD_REQUEST,
+				MessageCodes.REGISER_DENIED
+			);
 		}
-		ApiResponse.error(res, HttpStatusCodes.INTERNAL_SERVER_ERROR, 'There is been an unexpected error');
+		ApiResponse.error(
+			res,
+			HttpStatusCodes.INTERNAL_SERVER_ERROR,
+			MessageCodes.INTERNAL_SERVER_ERROR
+		);
 	}
 };

--- a/apps/server/src/controllers/health/index.ts
+++ b/apps/server/src/controllers/health/index.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from 'express';
 
 import { DatabaseService } from '../../services';
-import { HttpStatusCodes, ApiResponse } from '../../utils';
+import { HttpStatusCodes, ApiResponse, MessageCodes } from '../../utils';
 export const Health = {
 	get: async (_req: Request, res: Response) => {
 		try {
@@ -10,14 +10,14 @@ export const Health = {
 				res,
 				HttpStatusCodes.SUCCESS,
 				null,
-				'Database health is okay'
+				MessageCodes.SERVER_IS_ON
 			);
 		} catch (error) {
 			console.log(error);
 			return ApiResponse.error(
 				res,
 				HttpStatusCodes.INTERNAL_SERVER_ERROR,
-				'Error while checking database health'
+				MessageCodes.INTERNAL_SERVER_ERROR
 			);
 		}
 	},

--- a/apps/server/src/controllers/roles/index.ts
+++ b/apps/server/src/controllers/roles/index.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from 'express';
 import { RoleInterface } from '../../interfaces';
 import { roleProvider } from '../../providers/roles';
-import { HttpStatusCodes, ApiResponse } from '../../utils';
+import { HttpStatusCodes, ApiResponse, MessageCodes } from '../../utils';
 
 export const Role = {
 	get: {
@@ -13,7 +13,7 @@ export const Role = {
 					ApiResponse.error(
 						res,
 						HttpStatusCodes.NOT_FOUND,
-						'Role not found',
+						MessageCodes.ROLE_NOT_FOUND,
 						null
 					);
 				}
@@ -22,7 +22,7 @@ export const Role = {
 				ApiResponse.error(
 					res,
 					HttpStatusCodes.NOT_FOUND,
-					'Internal server error while looking for the role',
+					MessageCodes.INTERNAL_SERVER_ERROR,
 					null
 				);
 			}

--- a/apps/server/src/controllers/token/index.ts
+++ b/apps/server/src/controllers/token/index.ts
@@ -1,7 +1,7 @@
 import { Response, Request } from 'express';
 import { ExtractJwt } from 'passport-jwt';
 import { Secret, verify } from 'jsonwebtoken';
-import { ApiResponse, HttpStatusCodes } from '../../utils';
+import { ApiResponse, HttpStatusCodes, MessageCodes } from '../../utils';
 import { getEnvironment } from '../../services';
 
 export const Token = {
@@ -16,8 +16,10 @@ export const Token = {
 			);
 		}
 		try {
+			// get secret
 			const { SECRET } = getEnvironment();
-			// check signature
+
+			// check secret
 			const tokenDecoded: any = verify(token, SECRET as Secret);
 
 			// check token expiration
@@ -27,7 +29,7 @@ export const Token = {
 				return ApiResponse.error(
 					res,
 					HttpStatusCodes.UNAUTHORIZED,
-					'Token Expired',
+					MessageCodes.SESSION_EXPIRED,
 					null
 				);
 			}
@@ -36,7 +38,7 @@ export const Token = {
 			ApiResponse.error(
 				res,
 				HttpStatusCodes.UNAUTHORIZED,
-				'INVALID_TOKEN_SIGNATURE'
+				MessageCodes.SESSION_EXPIRED
 			);
 		}
 	},

--- a/apps/server/src/controllers/user/index.ts
+++ b/apps/server/src/controllers/user/index.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from 'express';
 
 import { UserProvider } from '../../providers/user';
-import { ApiResponse, HttpStatusCodes } from '../../utils/index';
+import { ApiResponse, HttpStatusCodes, MessageCodes } from '../../utils/index';
 import { cleanObjectNullKeys, getObjectKeys } from '../../utils/object.utils';
 import { cloudinaryService } from '../../services';
 
@@ -16,13 +16,13 @@ const User = {
 					res,
 					HttpStatusCodes.SUCCESS,
 					null,
-					'Account desactivated'
+					MessageCodes.ACCOUNT_DESACTIVATED
 				);
 			} catch (error) {
 				return ApiResponse.error(
 					res,
 					HttpStatusCodes.NOT_FOUND,
-					'Error while desactivating account, the user is already deleted or doesnt exist'
+					MessageCodes.USER_NOT_FOUND
 				);
 			}
 		},
@@ -39,12 +39,26 @@ const User = {
 					limit: finalLimit,
 					offset: finalOffset,
 				});
-				return ApiResponse.success(res, HttpStatusCodes.SUCCESS, users, '');
+
+				if (users.length <= 0) {
+					return ApiResponse.error(
+						res,
+						HttpStatusCodes.NOT_FOUND,
+						MessageCodes.USERS_NOT_FOUND
+					);
+				}
+
+				return ApiResponse.success(
+					res,
+					HttpStatusCodes.SUCCESS,
+					users,
+					MessageCodes.USER_FOUND
+				);
 			} catch (error) {
 				return ApiResponse.error(
 					res,
-					HttpStatusCodes.NOT_FOUND,
-					'Internal server error while looking for users'
+					HttpStatusCodes.INTERNAL_SERVER_ERROR,
+					MessageCodes.INTERNAL_SERVER_ERROR
 				);
 			}
 		},
@@ -56,16 +70,21 @@ const User = {
 					return ApiResponse.error(
 						res,
 						HttpStatusCodes.NOT_FOUND,
-						'User not found'
+						MessageCodes.USER_NOT_FOUND
 					);
 				}
 
-				ApiResponse.success(res, HttpStatusCodes.SUCCESS, user, '');
+				ApiResponse.success(
+					res,
+					HttpStatusCodes.SUCCESS,
+					user,
+					MessageCodes.USER_FOUND
+				);
 			} catch (error) {
 				ApiResponse.error(
 					res,
 					HttpStatusCodes.NOT_FOUND,
-					'Internal server error while looking for user'
+					MessageCodes.INTERNAL_SERVER_ERROR
 				);
 			}
 		},
@@ -77,16 +96,21 @@ const User = {
 					return ApiResponse.error(
 						res,
 						HttpStatusCodes.NOT_FOUND,
-						'User not found'
+						MessageCodes.USER_NOT_FOUND
 					);
 				}
 
-				ApiResponse.success(res, HttpStatusCodes.SUCCESS, user, '');
+				ApiResponse.success(
+					res,
+					HttpStatusCodes.SUCCESS,
+					user,
+					MessageCodes.USER_FOUND
+				);
 			} catch (error) {
 				return ApiResponse.error(
 					res,
 					HttpStatusCodes.NOT_FOUND,
-					'Internal server error while looking for user'
+					MessageCodes.INTERNAL_SERVER_ERROR
 				);
 			}
 		},
@@ -98,16 +122,21 @@ const User = {
 					return ApiResponse.error(
 						res,
 						HttpStatusCodes.NOT_FOUND,
-						'User not found'
+						MessageCodes.USER_NOT_FOUND
 					);
 				}
 
-				ApiResponse.success(res, HttpStatusCodes.SUCCESS, user, '');
+				ApiResponse.success(
+					res,
+					HttpStatusCodes.SUCCESS,
+					user,
+					MessageCodes.USER_FOUND
+				);
 			} catch (error) {
 				ApiResponse.error(
 					res,
 					HttpStatusCodes.NOT_FOUND,
-					'Internal server error while looking for user'
+					MessageCodes.INTERNAL_SERVER_ERROR
 				);
 			}
 		},
@@ -192,7 +221,7 @@ const User = {
 				return ApiResponse.error(
 					res,
 					HttpStatusCodes.BAD_REQUEST,
-					'no params provided',
+					'No params provided',
 					null
 				);
 			}
@@ -206,14 +235,14 @@ const User = {
 					res,
 					HttpStatusCodes.CREATED,
 					userWithUpdatedValues,
-					'User updated'
+					MessageCodes.DATA_UPDATED
 				);
 			} catch (error) {
 				console.log(error);
 				return ApiResponse.error(
 					res,
 					HttpStatusCodes.INTERNAL_SERVER_ERROR,
-					'Internal server error while updating user'
+					MessageCodes.INTERNAL_SERVER_ERROR
 				);
 			}
 		},
@@ -232,14 +261,14 @@ const User = {
 					res,
 					HttpStatusCodes.CREATED,
 					null,
-					'Dietary added to profile'
+					MessageCodes.DATA_UPDATED
 				);
 			} catch (error) {
 				console.log(error);
 				ApiResponse.error(
 					res,
 					HttpStatusCodes.INTERNAL_SERVER_ERROR,
-					'internal server error while adding dietary to profile'
+					MessageCodes.INTERNAL_SERVER_ERROR
 				);
 			}
 		},
@@ -256,14 +285,14 @@ const User = {
 					res,
 					HttpStatusCodes.CREATED,
 					null,
-					'dietary removed from profile'
+					MessageCodes.DATA_UPDATED
 				);
 			} catch (error) {
 				console.log(error);
 				ApiResponse.error(
 					res,
 					HttpStatusCodes.INTERNAL_SERVER_ERROR,
-					'internal server error while removing dietary from profilef'
+					MessageCodes.INTERNAL_SERVER_ERROR
 				);
 			}
 		},

--- a/apps/server/src/middlewares/auth/authorization.ts
+++ b/apps/server/src/middlewares/auth/authorization.ts
@@ -2,9 +2,11 @@ import { Request, Response, NextFunction } from 'express';
 import Jwt from 'jsonwebtoken';
 import { UserProvider } from '../../providers/user';
 import { ExtractJwt } from 'passport-jwt';
+import { ApiResponse, MessageCodes, HttpStatusCodes } from '../../utils';
+import { roleProvider } from '../../providers/roles';
 export async function authMiddleware(
 	req: Request,
-	_res: Response,
+	res: Response,
 	next: NextFunction
 ) {
 	const token = ExtractJwt.fromAuthHeaderAsBearerToken()(req);
@@ -19,12 +21,18 @@ export async function authMiddleware(
 		const idInParams = req.params.id;
 
 		if (!idInParams) {
-			return next(
-				'there migth be an issue. please contact us throght https://github.com/CulinaryAlchemy/CulinaryAlchemy/issues'
+			return ApiResponse.error(
+				res,
+				HttpStatusCodes.BAD_REQUEST,
+				'id is missing in params'
 			);
 		}
 		if (!userIdFromJwt) {
-			return next('Missing token');
+			return ApiResponse.error(
+				res,
+				HttpStatusCodes.UNAUTHORIZED,
+				MessageCodes.SESSION_EXPIRED
+			);
 		}
 
 		// if the user doesnt exist, reject
@@ -32,20 +40,31 @@ export async function authMiddleware(
 			parseInt(userIdFromJwt as string)
 		);
 		if (!user) {
-			return next('unauthorized');
+			return ApiResponse.error(
+				res,
+				HttpStatusCodes.UNAUTHORIZED,
+				MessageCodes.SESSION_EXPIRED
+			);
 		}
 		//if the user is admin, aprove
-		const adminRoleId = 2;
-		if (user.roleId && user.roleId === adminRoleId) {
+		const adminRole = await roleProvider.get.byName('admin');
+		if (user.roleId && adminRole && user.roleId === adminRole?.id) {
 			return next();
 		}
 		// if the user makes a request and the user id doesnt matches the req.params id, reject.
 		if (userIdFromJwt.toString() !== idInParams) {
-			return next('a');
+			return ApiResponse.error(
+				res,
+				HttpStatusCodes.BAD_REQUEST,
+				'The session id must match the id in param'
+			);
 		}
 		next();
 	} catch (error) {
-		console.log(error);
-		next('unauthorized');
+		return ApiResponse.error(
+			res,
+			HttpStatusCodes.UNAUTHORIZED,
+			MessageCodes.SESSION_EXPIRED
+		);
 	}
 }

--- a/apps/server/src/utils/index.ts
+++ b/apps/server/src/utils/index.ts
@@ -1,3 +1,3 @@
-import { ApiResponse, HttpStatusCodes } from './response-class';
+import { ApiResponse, HttpStatusCodes, MessageCodes } from './response-class';
 
-export { ApiResponse, HttpStatusCodes };
+export { ApiResponse, HttpStatusCodes, MessageCodes };

--- a/apps/server/src/utils/response-class.ts
+++ b/apps/server/src/utils/response-class.ts
@@ -12,7 +12,24 @@ const HttpStatusCodes = {
 	CONFLICT: 409,
 };
 
-export class ApiResponse {
+const MessageCodes = {
+	LOGIN_SUCCES: 'LOGIN_SUCCES',
+	LOGIN_DENIED: 'LOGIN_DENIED',
+	REGISER_SUCCES: 'REGISER_SUCCES',
+	REGISER_DENIED: 'REGISER_DENIED',
+	USER_FOUND: 'USER_FOUND',
+	USER_NOT_FOUND: 'USER_NOT_FOUND',
+	USERS_NOT_FOUND: 'USERS_NOT_FOUND',
+	ROLE_NOT_FOUND: 'ROLE_NOT_FOUND',
+	DATA_UPDATED: 'DATA_UPDATED',
+	SESSION_EXPIRED: 'SESSION_EXPIRED',
+	INTERNAL_SERVER_ERROR: 'INTERNAL_SERVER_ERROR',
+	ACCOUNT_DESACTIVATED: 'ACCOUNT_DESACTIVATED',
+	SERVER_IS_ON: 'SERVER_IS_ON',
+	SERVER_IS_OFF: 'SERVER_IS_OFF',
+};
+
+class ApiResponse {
 	private success: boolean;
 	private statusCode: number;
 	private data: any;
@@ -71,4 +88,4 @@ export class ApiResponse {
 	}
 }
 
-export { HttpStatusCodes };
+export { HttpStatusCodes, MessageCodes, ApiResponse };


### PR DESCRIPTION
this is what I have implemented in the backend:
```
LOGIN_SUCCES: 'LOGIN_SUCCES',
LOGIN_DENIED: 'LOGIN_DENIED',
REGISER_SUCCES: 'REGISER_SUCCES',
REGISER_DENIED: 'REGISER_DENIED',
USER_FOUND: 'USER_FOUND',
USER_NOT_FOUND: 'USER_NOT_FOUND',
USERS_NOT_FOUND: 'USERS_NOT_FOUND',
ROLE_NOT_FOUND: 'ROLE_NOT_FOUND',
DATA_UPDATED: 'DATA_UPDATED',
SESSION_EXPIRED: 'SESSION_EXPIRED',
INTERNAL_SERVER_ERROR: 'INTERNAL_SERVER_ERROR',
ACCOUNT_DESACTIVATED: 'ACCOUNT_DESACTIVATED',
SERVER_IS_ON: 'SERVER_IS_ON',
SERVER_IS_OFF: 'SERVER_IS_OFF',
```

I haven't changed the token JWT middleware, so the custom response won't apply to those cases. but the response already contains a status code of 401, so you can handle it in that case : )